### PR TITLE
httpResponse stream may be null

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,10 @@ KinesisStream.prototype._putRecords = function(requestContent) {
   })
   .on('complete', function() {
     req.removeAllListeners();
-    req.response.httpResponse.stream.removeAllListeners();
+    var response_stream = req.response.httpResponse.stream;
+    if (response_stream) {
+      response_stream.removeAllListeners();
+    }
     req.httpRequest.stream.removeAllListeners();
   });
 };


### PR DESCRIPTION
Check for null stream before removing their listeners

This is a fix for several uncaught logs like this:

`TypeError: Cannot read property 'removeAllListeners' of null
    at Request.<anonymous> (/usr/local/lib/node_modules/auth0-api2/node_modules/aws-kinesis-writable/index.js:165:37)`