### PR TITLE
Add retry to uncaught errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.2.36",
-    "lodash": "~3.10.1"
+    "lodash": "~3.10.1",
+    "retry": "^0.9.0"
   },
   "devDependencies": {
     "chai": "~2.3.0",


### PR DESCRIPTION
Caught any errors that `aws-sdk` may throw when we use `putRecords`.