### PR TITLE
Add the ability to use a pool of streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ var _ = require('lodash');
  * @param {number} [params.buffer.maxBatchSize] Max. size in bytes of the batch sent to Kinesis. Default 5242880 (5MiB)
  * @param {@function} [params.buffer.isPrioritaryMsg] Evaluates a message and returns true
  *                                                  when msg is prioritary
+ * @param {object} [params.retryConfiguration={}]
+ * @param {number} [params.retryConfiguration.retries=5] Number of retries to perform after a failed attempt
+ * @param {number} [params.retryConfiguration.factor=1.2] The exponential factor to use
+ * @param {number} [params.retryConfiguration.minTimeout=5000] The number of milliseconds before starting the first retry
+ * @param {boolean} [params.retryConfiguration.randomize=true] Randomizes the timeouts by multiplying with a factor between 1 to 2
  */
 
 var MAX_BATCH_SIZE = 5*1024*1024 - 1024; // 4.99MiB
@@ -37,7 +42,7 @@ function KinesisStream (params) {
     maxBatchSize: MAX_BATCH_SIZE
   };
 
-  this._retryConfiguration = {
+  this._retryConfiguration = params.retryConfiguration || {
     retries: 5,
     factor: 1.2,
     minTimeout: 5000,

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ KinesisStream.prototype._putRecords = function(requestContent) {
         try {
           self._queueWait = self._queueSendEntries();
           if (err) {
+            if (!err.records) err.records = requestContent.Records;
             throw err;
           }
 

--- a/pool.js
+++ b/pool.js
@@ -1,0 +1,122 @@
+const stream = require('stream');
+const util = require('util');
+const _ = require('lodash');
+
+/**
+ * KinesisStreamPool is a pool object that acts like a writable stream. It can
+ * be configured with multiple KinesisWritable streams; one of them will be the
+ * `currentStream` and that will be used to actually send data to Kinesis. In
+ * case of an error, `currentStream` will be switched to another one and the
+ * operations will be retried. After `params.retryPrimaryInterval`, the primary
+ * stream will be used again, and will continue as the `currentStream` if there
+ * are no errors.
+ *
+ * @param {Object} params
+ * @param {string} [params.streams] Streams that should be part of the pool
+ * @param {object} [params.retryPrimaryInterval] (optional) Time (in ms) to retry the primary stream again after a failure
+ * @param {object} [params.logger] (optional) Object responding to `info` and `error`
+ */
+
+function KinesisStreamPool (params) {
+  stream.Writable.call(this, { objectMode: params.objectMode });
+  this.streams = params.streams;
+  this.retryPrimaryInterval = params.retryPrimaryInterval || (5 * 60 * 1000);
+  this.logger = params.logger || console;
+  this.debug = params.debug || false;
+
+  this.primaryStream = _.find(this.streams, (stream) => {
+    return stream.primary;
+  });
+  // if no stream is defined as primary, use the first one
+  // in the array
+  if (!this.primaryStream) {
+    this.streams[0].primary = true;
+    this.primaryStream = this.streams[0];
+  }
+  this.currentStream = this.primaryStream;
+  this.recordsToRetry = [];
+
+  // bind failover logic to each stream's 'error' event
+  var self = this;
+  _.map(this.streams, (stream, index) => {
+    stream.streamId = index;
+    stream.on('error', (err) => {
+      if (err.records) {
+        self.recordsToRetry = _.union(self.recordsToRetry, Array.isArray(err.records) ? err.records : [err.records]);
+      }
+
+      // new stream failing
+      stream.failing = true;
+      self.latestFailingStream = stream;
+
+      // try to get primary again, but if it's failing try another
+      if (!self.primaryStream.failing) {
+        self.currentStream = self.primaryStream;
+      } else {
+        var nextStream = _.find(self.streams, (stream) => {
+          return !stream.failing;
+        });
+        if (nextStream) self.currentStream = nextStream;
+      }
+
+      // if everything fails, emit error; otherwise, retry what
+      // was in the buffer with the current (non-failing) stream
+      if (self.currentStream.failing) {
+        self.emit('error', err);
+      } else {
+        self.retrySendingRecords();
+      }
+    });
+  });
+
+  // retry using the primary from time to time after a failure
+  setInterval(() => {
+    if (!self.primaryStream.failing) return;
+
+    // reset primary stream
+    self.primaryStream.failing = false;
+    self.currentStream = self.primaryStream;
+
+    // reset other streams
+    _.map(self.streams, (stream) => {
+      stream.failing = false;
+    });
+
+    self.retrySendingRecords();
+  }, self.retryPrimaryInterval);
+
+  self.on('error', function () {
+    var everythingIsFailing = _.every(self.streams, (stream) => {
+      return stream.failing === true;
+    });
+    if (everythingIsFailing) {
+      self.emit('poolFailure', new Error('No kinesis stream available'));
+    }
+  });
+}
+
+util.inherits(KinesisStreamPool, stream.Writable);
+
+KinesisStreamPool.prototype._write = function (chunk, encoding, done) {
+  if (this.debug) this.logger.info(`Writing to ${this.currentStream.streamId}`);
+  this.currentStream.write(chunk, encoding, done);
+};
+
+KinesisStreamPool.prototype.retrySendingRecords = function () {
+  var self = this;
+  if (self.debug) self.logger.info(`Retrying sending records to ${this.currentStream.streamId}`);
+  while(self.recordsToRetry.length > 0 && !self.currentStream.failing) {
+    var records = self.recordsToRetry.shift();
+    self.currentStream.write(records.Data ? records.Data : records);
+  }
+};
+
+KinesisStreamPool.prototype.setStreamName = function (streamName) {
+  this.currentStream.setStreamName(streamName);
+};
+
+KinesisStreamPool.prototype.getStreamName = function () {
+  return this.currentStream.getStreamName();
+};
+
+module.exports = KinesisStreamPool;

--- a/test/pool.tests.js
+++ b/test/pool.tests.js
@@ -1,0 +1,165 @@
+const KinesisStreamPool = require('../pool');
+const stream = require('stream');
+
+const assert = require('chai').assert;
+
+console.info = console.error = () => {};
+
+describe('KinesisStreamPool', () => {
+  it ('should set up initial state', (done) => {
+    var streams = [
+      new stream.Writable({
+        objectMode: true,
+        write: () => {}
+      }),
+      new stream.Writable({
+        objectMode: true,
+        write: () => {}
+      })
+    ];
+    streams[1].primary = true;
+
+    var pool = new KinesisStreamPool({
+      streams: streams
+    });
+    assert.ok(pool.primaryStream);
+    assert.ok(pool.currentStream);
+    assert.equal(pool.primaryStream, streams[1]);
+    assert.equal(pool.primaryStream, pool.currentStream);
+    assert.equal(pool.retryPrimaryInterval, 300000);
+    assert.equal(pool.logger, console);
+    done();
+  });
+
+  it ('should write to the primary stream', (done) => {
+    var streams = [
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk) => {
+          assert.deepEqual(chunk, { foo: 'bar' });
+          done();
+        }
+      }),
+      new stream.Writable({
+        objectMode: true,
+        write: () => {}
+      })
+    ];
+
+    var pool = new KinesisStreamPool({
+      objectMode: true,
+      streams: streams
+    });
+    assert.equal(pool.primaryStream, streams[0]);
+    assert.equal(pool.primaryStream, pool.currentStream);
+    pool.write({ foo: 'bar' });
+  });
+
+  it ('should switch streams in case of an issue with the primary', (done) => {
+    var pool;
+    var streams = [
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk, encoding, cb) => {
+          var err = new Error('houston, we have a problem');
+          err.records = [chunk];
+          cb(err);
+        }
+      }),
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk) => {
+          assert.notEqual(pool.currentStream, pool.primaryStream);
+          assert.deepEqual(chunk, { lol: 'lero' });
+          done();
+        }
+      })
+    ];
+
+    pool = new KinesisStreamPool({
+      objectMode: true,
+      streams: streams
+    });
+    assert.equal(pool.primaryStream, streams[0]);
+    assert.equal(pool.primaryStream, pool.currentStream);
+    pool.write({ lol: 'lero' });
+  });
+
+  it ('should switch to the primary again after some time', (done) => {
+    var streams = [
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk, encoding, cb) => {
+          var err = new Error('houston, we have a temporary problem');
+          err.records = [chunk];
+          cb(err);
+        }
+      }),
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk, encoding, cb) => {
+          assert.deepEqual(chunk, { hihihi: 'hahaha' });
+          cb();
+        }
+      })
+    ];
+
+    var pool = new KinesisStreamPool({
+      objectMode: true,
+      streams: streams,
+      retryPrimaryInterval: 1000
+    });
+    assert.equal(pool.primaryStream, streams[0]);
+    assert.equal(pool.primaryStream, pool.currentStream);
+    pool.write({ hihihi: 'hahaha' });
+    setTimeout(() => {
+      assert.notEqual(pool.currentStream, pool.primaryStream);
+      assert.equal(pool.primaryStream.failing, true);
+    }, 500);
+    setTimeout(() => {
+      assert.equal(pool.currentStream, pool.primaryStream);
+      assert.equal(pool.primaryStream.failing, false);
+      done();
+    }, 1200);
+  });
+
+  it ('should emit an error event in case of total failure', (done) => {
+    var pool;
+    var streams = [
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk, encoding, cb) => {
+          var err = new Error('houston, we have a different problem');
+          err.records = {
+            Data: JSON.stringify(chunk),
+            length: JSON.stringify(chunk).length
+          };
+          cb(err);
+        }
+      }),
+      new stream.Writable({
+        objectMode: true,
+        write: (chunk, encoding, cb) => {
+          var err = new Error('houston, we have yet another problem');
+          err.records = {
+            Data: JSON.stringify(chunk),
+            length: JSON.stringify(chunk).length
+          };
+          cb(err);
+        }
+      })
+    ];
+
+    pool = new KinesisStreamPool({
+      objectMode: true,
+      streams: streams
+    });
+    pool.on('poolFailure', (err) => {
+      assert.equal(err.message, 'No kinesis stream available');
+    });
+    assert.equal(pool.primaryStream, streams[0]);
+    assert.equal(pool.primaryStream, pool.currentStream);
+    pool.write({ pum: 'pa' });
+    setTimeout(done, 500);
+  });
+});


### PR DESCRIPTION
This make it possible write to a pool of kinesis streams: only one of them will be used at a time, and the current stream will automatically switch to another in case of an error. This can be used as a failover mechanism in case Kinesis fails in one AWS region.