### PR TITLE
Allow kinesis streams from modern browsers, passing in credentials object for CognitoIdentityCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ new KinesisWritable({
 
 `streamName` is the name of the Kinesis Stream.
 
+`credentials` is an existing credentials object e.g. a successful `CognitoIdentityCredentials` request
 ### Events
 
 * `error`: Emitted every time records are failed to be written.

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function KinesisStream (params) {
   this.hasPriority = this.buffer.isPrioritaryMsg || this.buffer.hasPriority;
 
   // increase the timeout to get credentials from the EC2 Metadata Service
-  AWS.config.credentials = new AWS.EC2MetadataCredentials({
+  AWS.config.credentials = params.credentials || new AWS.EC2MetadataCredentials({
     httpOptions: params.httpOptions || { timeout: 5000 }
   });
 
@@ -142,7 +142,7 @@ KinesisStream.prototype.putRecords = function(records, cb) {
   req.on('complete', function() {
     req.removeAllListeners();
     req.response.httpResponse.stream.removeAllListeners();
-    req.httpRequest.stream.removeAllListeners();
+    req.httpRequest.stream.removeAllListeners && req.httpRequest.stream.removeAllListeners();
   });
 };
 


### PR DESCRIPTION
Allow passing in credentials object so we can use CognitoIdentityCredentials
Includes a check on calls to non-browser based methods.

This will allow browser streams to kinesis (+ onwards to elastic search) from a web browser. Passing in CognitoIdentityCredentials allows token creation specific for the users without embedding accessKeyId & accessSecret in client-side code. 
