### PR TITLE
Pass the endpoint parameter to the AWS constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const merge = require('lodash.merge');
  * @param {string} [params.accessKeyId] AWS credentials
  * @param {string} [params.secretAccessKey] AWS credential
  * @param {string} [params.region] AWS region
+ * @param {string} [params.endpoint] AWS HTTP endpoint
  * @param {string} params.streamName AWS Knesis stream name
  * @param {function} params.partitionKey function that return the partitionKey based on a msg passed by argument
  * @param {object} [params.httpOptions={}] HTTP options that will be used on `aws-sdk` (e.g. timeout values)
@@ -61,6 +62,7 @@ function KinesisStream (params) {
     accessKeyId: params.accessKeyId,
     secretAccessKey: params.secretAccessKey,
     region: params.region,
+    endpoint: params.endpoint,
     httpOptions: params.httpOptions
   });
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ const merge = require('lodash.merge');
  * @param {string} [params.secretAccessKey] AWS credential
  * @param {string} [params.region] AWS region
  * @param {string} [params.endpoint] AWS HTTP endpoint
+ * @param {string} [params.objectMode] True if Javascript objects can be directly written to Kinesis
+ *                                     (instead of strings)
  * @param {string} params.streamName AWS Knesis stream name
  * @param {function} params.partitionKey function that return the partitionKey based on a msg passed by argument
  * @param {object} [params.httpOptions={}] HTTP options that will be used on `aws-sdk` (e.g. timeout values)
@@ -63,6 +65,7 @@ function KinesisStream (params) {
     secretAccessKey: params.secretAccessKey,
     region: params.region,
     endpoint: params.endpoint,
+    objectMode: params.objectMode,
     httpOptions: params.httpOptions
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -20,9 +20,10 @@ describe('KinesisStream', function() {
       expect(ks.recordsQueue).to.exist;
       expect(ks.partitionKey).to.be.function;
     });
-    it('should build a stream with configured endpoint', function() {
+    it('should build a stream with configured endpoint and objectMode', function() {
       const ks = new KinesisStream({
         streamName: 'test',
+        objectMode: true,
         kinesis: {
           endpoint: "http://somehost:1234"
         }
@@ -32,6 +33,7 @@ describe('KinesisStream', function() {
       expect(ks.recordsQueue).to.exist;
       expect(ks.partitionKey).to.be.function;
       expect(ks.kinesis.endpoint).to.equal("http://somehost:1234");
+      expect(ks._writableState.objectMode).to.equal(true);
     });
   });
   describe('#_write', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,19 @@ describe('KinesisStream', function() {
       expect(ks.recordsQueue).to.exist;
       expect(ks.partitionKey).to.be.function;
     });
+    it('should build a stream with configured endpoint', function() {
+      const ks = new KinesisStream({
+        streamName: 'test',
+        kinesis: {
+          endpoint: "http://somehost:1234"
+        }
+      });
+
+      expect(ks.hasPriority).to.be.function;
+      expect(ks.recordsQueue).to.exist;
+      expect(ks.partitionKey).to.be.function;
+      expect(ks.kinesis.endpoint).to.equal("http://somehost:1234");
+    });
   });
   describe('#_write', function() {
     var ks;


### PR DESCRIPTION
Allow the built-in Kinesis parameter [endpoint](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#kinesis-property) to be passed from the `KinesisStream` constructor to the AWS one.  This will allow the value to be overwritten to ease testing with [localstack](https://github.com/localstack/localstack) or similar testing frameworks.

The [objectMode](https://nodejs.org/api/stream.html#stream_object_mode) also can be set for the writable stream further up the stack, namely in `auth0-worker-lib`.  This seems to be helpful for newer versions of the `aws-sdk`.