### PR TITLE
Fix partitionKey to consume record

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,9 +109,10 @@ KinesisStream.prototype.dispatch = function(records, cb) {
 
   const operation = retry.operation(this.buffer.retry);
 
-  const partitionKey = this.partitionKey();
-
   const formattedRecords = records.map((record) => {
+    const partitionKey = typeof this.partitionKey === 'function'
+	  ? this.partitionKey(record)
+	  : this.partitionKey;
     return { Data: JSON.stringify(record), PartitionKey: partitionKey };
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -16,9 +16,9 @@ describe('KinesisStream', function() {
         kinesis: {}
       });
 
-      expect(ks.hasPriority).to.be.function;
+      expect(ks.hasPriority).to.be.a('function');
       expect(ks.recordsQueue).to.exist;
-      expect(ks.partitionKey).to.be.function;
+      expect(ks.partitionKey).to.be.string;
     });
   });
   describe('#_write', function() {


### PR DESCRIPTION
According to the README, the `partitionKey` method `can be either an string or a function that accepts a message and returns a string`.