### PR TITLE
Update aws-sdk to >= 2.178.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+<a name="v4.1.4"></a>
+# v4.1.4
+- Update the AWS SDK to at least version 2.178.0 which has an updated version of crypto-browserify  which as vulnerable to Insecure Randomness due to using the cryptographically insecure Math.random().  See https://snyk.io/test/npm/aws-sdk/2.94.0.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-kinesis-writable",
   "description": "A stream implementation for kinesis.",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "repository": {
     "url": "git://github.com/auth0/kinesis-writable.git"
@@ -12,7 +12,7 @@
     "cover": "NODE_ENV=test istanbul cover _mocha -- -R spec --timeout 5000"
   },
   "dependencies": {
-    "aws-sdk": "^2.94.0",
+    "aws-sdk": "^2.178.0",
     "lodash.merge": "^4.6.0",
     "retry": "^0.10.1"
   },


### PR DESCRIPTION
Snyk flagged older versions of the AWS SDK to have a security error: https://snyk.io/test/npm/aws-sdk/2.94.0.  This was just fixed in the latest release to remove the dependency on `crypto-browserify` https://github.com/aws/aws-sdk-js/commit/0638060402931f572f9f75d77a12bd6c529b0424