### PR TITLE
Keep credential provider chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,7 @@ function KinesisStream (params) {
   this.hasPriority = this.buffer.isPrioritaryMsg || this.buffer.hasPriority;
 
   // increase the timeout to get credentials from the EC2 Metadata Service
-  AWS.config.credentials = new AWS.EC2MetadataCredentials({
-    httpOptions: { timeout: 5000 }
-  });
+  AWS.EC2MetadataCredentials.prototype.defaultTimeout = 5000;
 
   this.recordsQueue = [];
 


### PR DESCRIPTION
This PR will change the way the increased timeout for the `AWS.EC2MetadataCredentials` is set.

Currently this library is hard overriding anything that might have been set as the credentials source by the surrounding application and/or environment.
It makes it impossible to provide credentials via a configuration file in `~/.aws` or environment variables not only for the kinesis stream writer but for the whole application using the `KinesisStream` class.

This behaviour was introduced by removing the configuration gate `params.getCredentialsFromIAMRole` [here](https://github.com/auth0/kinesis-writable/commit/2069b504f1cea33c1c1bd08feb90612359af04d7#diff-168726dbe96b3ce427e7fedce31bb0bcL82)

A minimal demo for the problem using environment variables:
```javascript
const assert = require('assert');

process.env.AWS_ACCESS_KEY_ID = 'dummy';
process.env.AWS_SECRET_ACCESS_KEY = 'invalid';

const AWS = require('aws-sdk');

assert(AWS.config.credentials instanceof AWS.EnvironmentCredentials,
  'Unexpected provider before KinesisWritable');

const KinesisWritable = require('aws-kinesis-writable');
new KinesisWritable({ streamName: 'invalid' });

assert(AWS.config.credentials instanceof AWS.EnvironmentCredentials,
  'Unexpected provider after KinesisWritable');
```
