### PR TITLE
ensure timeout doesn't get delayed by new messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,13 +99,13 @@ KinesisStream.prototype._write = function(chunk, enc, next) {
     this.recordsQueue.push(chunk);
   }
 
-  if (this.timer) {
-    clearTimeout(this.timer);
-  }
-
   if (this.recordsQueue.length >= this.buffer.length || hasPriority) {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
     this.flush();
-  } else {
+  } else if (!this.timer) {
     this.timer = setTimeout(this.flush.bind(this), this.buffer.timeout * 1000);
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -69,10 +69,19 @@ describe('KinesisStream', function() {
     });
     it('should call #dispatch once timer hits', function(done) {
       this.timeout(3000);
-      ks.buffer.timeout = 2;
-      for (var i = 0; i < 3; i++) {
-        ks.write(new Buffer(JSON.stringify(message)));
-      }
+      ks.buffer.timeout = 1;
+      // write one message to start timeout
+      ks.write(new Buffer(JSON.stringify(message)));
+      // write another after 500ms.
+      setTimeout(() => ks.write(new Buffer(JSON.stringify(message))), 500);
+      // write another after 750ms.
+      setTimeout(() => ks.write(new Buffer(JSON.stringify(message))), 750);
+      // at 1100 ms timer should have fired still.
+      setTimeout(function() {
+        expect(ks.dispatch.calledOnce).to.be.true;
+        expect(ks.dispatch.calledWith([message, message, message])).to.be.true;
+      }, 1100);
+      // and at 2 seconds it should not have fired again ...
       setTimeout(function() {
         expect(ks.dispatch.calledOnce).to.be.true;
         expect(ks.dispatch.calledWith([message, message, message])).to.be.true;


### PR DESCRIPTION
Ensure that the timeout value is the upper bound, rather than lower bound of delay.  Otherwise messages can be delayed until the max buffer size if they are trickled in slowly.

This will increase kinesis write rates on minimally loaded producers, but will have little to no effect on loaded systems.